### PR TITLE
Add explicit database model imports in db operations

### DIFF
--- a/backend/db_operations.py
+++ b/backend/db_operations.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 from sqlalchemy.orm import Session
 from datetime import datetime, timedelta
 import bcrypt
+from database import User, Novel, Chapter, GenerationLog, UserTemplate
 
 
 class DatabaseOperations:


### PR DESCRIPTION
## Summary
- import `User`, `Novel`, `Chapter`, `GenerationLog`, and `UserTemplate` in `db_operations`
- verified the imported models correspond to those defined in `backend/database.py`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68971cc995688322b3f9db20d4a2cd6f