### PR TITLE
feat: persist task status

### DIFF
--- a/backend/novel_generator.py
+++ b/backend/novel_generator.py
@@ -3,6 +3,7 @@ from typing import Dict, List
 import tiktoken
 import asyncio
 from tenacity import retry, stop_after_attempt, wait_exponential
+from redis_cache import RedisCache
 
 
 class NovelGenerator:
@@ -12,6 +13,7 @@ class NovelGenerator:
         openai.api_key = api_key
         self.encoding = tiktoken.encoding_for_model(model)
         self.templates = PromptTemplates()
+        self.cache = RedisCache()
 
     async def generate_novel(self, request: NovelRequest, task_id: str) -> Dict:
         """主生成流程"""
@@ -171,5 +173,9 @@ class NovelGenerator:
     async def update_task_status(self, task_id: str, status: NovelStatus,
                                  progress: int = 0, error: str = None):
         """更新任务状态到Redis"""
-        # 这里应该更新到Redis或数据库
-        pass
+        try:
+            status_value = status.value if hasattr(status, "value") else status
+            self.cache.update_task_status(task_id, status_value, progress, error)
+        except Exception as e:
+            # 避免状态更新失败中断生成流程
+            print(f"Failed to update status for {task_id}: {e}")

--- a/backend/redis_cache.py
+++ b/backend/redis_cache.py
@@ -3,7 +3,7 @@ import redis
 import json
 import pickle
 from typing import Any, Optional
-from datetime import timedelta
+from datetime import timedelta, datetime
 import hashlib
 
 
@@ -60,15 +60,17 @@ class RedisCache:
         value = self.redis_client.get(key)
         return self._deserialize(value)
 
-    def update_task_status(self, task_id: str, status: str, progress: int = None) -> None:
+    def update_task_status(self, task_id: str, status: str, progress: int = None,
+                           error: str = None) -> None:
         """更新任务状态"""
-        task = self.get_task(task_id)
-        if task:
-            task['status'] = status
-            if progress is not None:
-                task['progress'] = progress
-            task['updated_at'] = datetime.utcnow().isoformat()
-            self.set_task(task_id, task)
+        task = self.get_task(task_id) or {}
+        task['status'] = status
+        if progress is not None:
+            task['progress'] = progress
+        if error is not None:
+            task['error'] = error
+        task['updated_at'] = datetime.utcnow().isoformat()
+        self.set_task(task_id, task)
 
     # ========== 结果缓存 ==========
 


### PR DESCRIPTION
## Summary
- store task status and errors in Redis via update_task_status
- extend RedisCache to handle progress/error metadata

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68971cc752b08322947ab75c28e8f22e