### PR TITLE
Add missing imports to prompt templates

### DIFF
--- a/backend/prompt_templates.py
+++ b/backend/prompt_templates.py
@@ -1,3 +1,7 @@
+from typing import Dict
+import json
+
+
 class PromptTemplates:
     """提示词模板管理"""
 


### PR DESCRIPTION
## Summary
- import Dict type and json module in prompt template definitions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68971cc142148322b2d6d715097d750c