### PR TITLE
refactor: centralize shared models

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,19 +1,15 @@
 # main.py - 主应用入口
 from fastapi import FastAPI, HTTPException, BackgroundTasks
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
-from typing import Optional, List, Dict
+from typing import List, Dict
 import asyncio
 import json
 import uuid
 from datetime import datetime
-from enum import Enum
 
 # 导入其他模块
 from novel_generator import NovelGenerator
-from prompt_templates import PromptTemplates
-from database import SessionLocal
-from redis_cache import RedisCache
+from models import NovelRequest, NovelStatus, NovelTask
 
 app = FastAPI(title="AI小说生成系统")
 
@@ -28,44 +24,11 @@ app.add_middleware(
 
 
 # ============== 数据模型 ==============
-
-class NovelGenre(str, Enum):
-    URBAN_ROMANCE = "urban_romance"
-    MYSTERY = "mystery"
-    SCIFI = "scifi"
-    WORKPLACE = "workplace"
-    FANTASY = "fantasy"
-
-
-class NovelRequest(BaseModel):
-    theme: str  # 用户输入的主题
-    genre: Optional[NovelGenre] = None
-    style: Optional[str] = "知乎风格"
-    word_count: Optional[int] = 30000
-    chapter_count: Optional[int] = 12
-
-
-class NovelStatus(str, Enum):
-    PENDING = "pending"
-    OUTLINING = "outlining"
-    WRITING = "writing"
-    POLISHING = "polishing"
-    COMPLETED = "completed"
-    FAILED = "failed"
-
-
-class NovelTask(BaseModel):
-    task_id: str
-    status: NovelStatus
-    progress: int  # 0-100
-    current_stage: str
-    created_at: datetime
-    updated_at: datetime
-    result: Optional[Dict] = None
-    error: Optional[str] = None
+# 见 models.py
 
 # 任务存储（实际应用中应使用Redis）
 tasks_db = {}
+
 
 
 @app.post("/api/novel/generate", response_model=Dict)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,41 @@
+from enum import Enum
+from datetime import datetime
+from typing import Optional, Dict
+
+from pydantic import BaseModel
+
+
+class NovelGenre(str, Enum):
+    URBAN_ROMANCE = "urban_romance"
+    MYSTERY = "mystery"
+    SCIFI = "scifi"
+    WORKPLACE = "workplace"
+    FANTASY = "fantasy"
+
+
+class NovelRequest(BaseModel):
+    theme: str
+    genre: Optional[NovelGenre] = None
+    style: Optional[str] = "知乎风格"
+    word_count: Optional[int] = 30000
+    chapter_count: Optional[int] = 12
+
+
+class NovelStatus(str, Enum):
+    PENDING = "pending"
+    OUTLINING = "outlining"
+    WRITING = "writing"
+    POLISHING = "polishing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class NovelTask(BaseModel):
+    task_id: str
+    status: NovelStatus
+    progress: int  # 0-100
+    current_stage: str
+    created_at: datetime
+    updated_at: datetime
+    result: Optional[Dict] = None
+    error: Optional[str] = None

--- a/backend/novel_generator.py
+++ b/backend/novel_generator.py
@@ -7,7 +7,7 @@ from redis_cache import RedisCache
 import json
 from datetime import datetime
 from prompt_templates import PromptTemplates
-from main import NovelRequest, NovelStatus  # adjust path if models move
+from models import NovelRequest, NovelStatus
 
 
 class NovelGenerator:


### PR DESCRIPTION
## Summary
- extract NovelGenre, NovelRequest, NovelStatus, and NovelTask into new backend/models.py for reuse
- update backend/main.py and backend/novel_generator.py to import shared models
- drop in-place model declarations and unused imports

## Testing
- `python -m py_compile backend/models.py backend/main.py backend/novel_generator.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689722c608cc8322908f67de0445a1f2