### PR TITLE
Add missing UUID and time imports for Redis lock

### DIFF
--- a/backend/redis_cache.py
+++ b/backend/redis_cache.py
@@ -5,6 +5,8 @@ import pickle
 from typing import Any, Optional
 from datetime import timedelta, datetime
 import hashlib
+import uuid
+import time
 
 
 class RedisCache:


### PR DESCRIPTION
## Summary
- import uuid and time in redis_cache to support distributed lock helpers

## Testing
- `python - <<'PY'
from backend.redis_cache import RedisCache

class DummyRedis:
    def __init__(self):
        self.store = {}
    def set(self, key, identifier, nx=False, ex=None):
        if nx and key in self.store:
            return False
        self.store[key] = identifier
        return True
    def delete(self, key):
        return int(self.store.pop(key, None) is not None)

cache = RedisCache()
cache.redis_client = DummyRedis()

assert cache.acquire_lock('test_lock', timeout=0.01) is True
assert cache.acquire_lock('test_lock', timeout=0.01) is False
assert cache.release_lock('test_lock') is True
print('acquire_lock tests passed')
PY`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689722c738808322bb11a3ad95e2a074