### PR TITLE
Use environment variable for OpenAI API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,11 @@ docker run -d --name redis -p 6379:6379 redis:alpine
 ```
 
 ### 4. 启动后端
+在启动前请确保已设置 `OPENAI_API_KEY` 环境变量：
 
 ```bash
 cd backend
+export OPENAI_API_KEY=sk-your-api-key  # 或在环境中预先设置
 uvicorn main:app --reload --host 0.0.0.0 --port 8000
 ```
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,6 +8,7 @@ import json
 import uuid
 from datetime import datetime
 from enum import Enum
+import os
 
 # 导入其他模块
 from novel_generator import NovelGenerator
@@ -101,7 +102,8 @@ async def generate_novel(request: NovelRequest, background_tasks: BackgroundTask
 
 async def process_novel_generation(task_id: str, request: NovelRequest):
     """后台处理小说生成"""
-    generator = NovelGenerator(api_key="your-openai-api-key")
+    api_key = os.getenv("OPENAI_API_KEY")
+    generator = NovelGenerator(api_key=api_key)
 
     try:
         result = await generator.generate_novel(request, task_id)


### PR DESCRIPTION
## Summary
- Read OpenAI API key from `OPENAI_API_KEY` environment variable when instantiating `NovelGenerator`
- Document required `OPENAI_API_KEY` environment variable in backend startup instructions

## Testing
- `pytest` (no tests discovered)


------
https://chatgpt.com/codex/tasks/task_e_689722c93cbc83229c1afd0ceca1060f