### PR TITLE
Add PostCSS config for Tailwind in frontend

### DIFF
--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};


### PR DESCRIPTION
## Summary
- add PostCSS configuration enabling Tailwind CSS and Autoprefixer

## Testing
- `CI=true npm test -- --passWithNoTests`
- `CI=true npm run build` *(fails: Could not find a required file. Name: index.js)*

------
https://chatgpt.com/codex/tasks/task_e_6897319553e48322a70ccc45b219ddd2